### PR TITLE
Make it possible to build on Android Studio 3.1.3.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,14 @@ def pwd = new File('.').absolutePath
 buildscript {
 	repositories {
 		mavenCentral()
+		maven {
+			url 'https://maven.google.com/'
+			name 'Google'
+		}
 	}
 
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.1.3'
+		classpath 'com.android.tools.build:gradle:3.1.3'
 		//classpath 'com.jakewharton.hugo:hugo-plugin:1.1.0'
 	}
 }
@@ -18,6 +22,10 @@ repositories {
 	mavenCentral()
 	maven {
 		url "file://$pwd/.m2repo"
+	}
+	maven {
+		url 'https://maven.google.com/'
+		name 'Google'
 	}
 }
 
@@ -38,8 +46,8 @@ dependencies {
 
 
 android {
-	buildToolsVersion '23.0.1'
-	compileSdkVersion 24
+	//buildToolsVersion '23.0.1'
+	compileSdkVersion 26
 
 	defaultConfig {
 		minSdkVersion 14


### PR DESCRIPTION
The project suffered from bitrot - gradle sync failed on Android Studio 3.1.3.
The changes made to build.gradle allowed the project to build.
Tests:
1. Debug variant ran on an Android 8.1 emulated device.
1. All androidTest tests passed on the above emulated device.