### PR TITLE
solve issue of low contrast

### DIFF
--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -68,6 +68,7 @@
 		<item name="colorPrimary">@color/color_primary</item>
 		<item name="colorPrimaryDark">@color/color_primary_dark</item>
 		<item name="colorAccent">@color/color_accent</item>
+		<item name="titleTextColor">#282828</item>
 
 		<!--
         <item name="buttonBarStyle">@style/Theme.RxDroid.ButtonBar</item>


### PR DESCRIPTION
The original text color of the component is '#FFFFFF', and the contrast between the text color ('#FFFFFF') and the background color ('#FF5722') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#282828') are as follows:
![image](https://user-images.githubusercontent.com/101503193/167430688-b94fb1fe-17c1-4e2b-8132-88e26ce790e3.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.