### PR TITLE
fixing issue 39

### DIFF
--- a/src/main/java/at/jclehner/rxdroid/NotificationReceiver.java
+++ b/src/main/java/at/jclehner/rxdroid/NotificationReceiver.java
@@ -563,7 +563,7 @@ public class NotificationReceiver extends BroadcastReceiver
 					CHANNEL_DEFAULT);
 			builder.setContentIntent(createDrugListIntent(mDate));
 			builder.setTicker(getString(R.string._msg_new_notification));
-			builder.setCategory(NotificationCompat.CATEGORY_ALARM);
+			builder.setCategory(NotificationCompat.CATEGORY_REMINDER);
 			builder.setColor(!BuildConfig.DEBUG ? Theme.getColorAttribute(R.attr.colorPrimary) : Color.GREEN);
 			builder.setWhen(0);
 


### PR DESCRIPTION
This should fix https://github.com/jclehner/rxdroid/issues/39
Exact same as this commit: https://github.com/rallyemax/rxdroid/commit/70a2aa3b5e8accd699f73aa3fd14b1288f1c46f8

Many people have "allowing alarms" as an exception in their "do not disturb"-settings.
Now because rxdroid notifications appear to be classified as “alarms”, the rxdroid notifications are not muted when DND is enabled.

See;
https://developer.android.com/reference/android/app/NotificationManager#INTERRUPTION_FILTER_ALARMS

I feel this would be a more natural default for many people;
if one still wants to hear their notifications (assuming this fix) with DND turned on, one could always add this application as an exception (in the DND settings)